### PR TITLE
fixed indexing of atc_post.json()

### DIFF
--- a/opensupreme/atc_checkout.py
+++ b/opensupreme/atc_checkout.py
@@ -36,7 +36,7 @@ def add_to_cart(item_id, size_id, style_id, task_name, screenlock):
 
     atc_post = s.post(atc_url, headers=headers, data=data)
     if atc_post.json():
-        if atc_post.json()[0]["in_stock"]:
+        if atc_post.json()['cart'][0]["in_stock"]:
             with screenlock:
                 print(colored(f"{task_name}: Added to Cart", "blue"))
             return s 


### PR DESCRIPTION
atc_post.json() was: {'cart': [{'size_id': '80915', 'in_stock': True}], 'success': True} 
doing atc_post.json()[0]['in_stock'] was giving a key error . Changed to atc_post.json()['cart'][0]['in_stock']