### PR TITLE
Prevent invalid index access error

### DIFF
--- a/opensupreme/atc_checkout.py
+++ b/opensupreme/atc_checkout.py
@@ -36,7 +36,7 @@ def add_to_cart(item_id, size_id, style_id, task_name, screenlock):
 
     atc_post = s.post(atc_url, headers=headers, data=data)
     if atc_post.json():
-        if atc_post.json()['cart'][0]["in_stock"]:
+        if len(atc_post.json()['cart']) > 0 and atc_post.json()['cart'][0]["in_stock"]:
             with screenlock:
                 print(colored(f"{task_name}: Added to Cart", "blue"))
             return s 


### PR DESCRIPTION
Prevents an error from being thrown when an empty cart is returned.